### PR TITLE
Add keyboard shortcut to open the page on 12ft.io

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
     },
     "node_modules/@types/chrome": {
       "version": "0.0.174",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/chrome/-/chrome-0.0.174.tgz",
-      "integrity": "sha1-7hZ586T8V7ssO3aVeEWmivt9R4w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26,8 +24,6 @@
     },
     "node_modules/@types/filesystem": {
       "version": "0.0.32",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha1-MH33zAhKIpPDwaMRUbF4Bj4Kjt8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -36,22 +32,16 @@
     },
     "node_modules/@types/filewriter": {
       "version": "0.0.29",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha1-pIeV7K35V/bA0Q4MNK+GwJj6W+4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/har-format": {
       "version": "1.2.8",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/har-format/-/har-format-1.2.8.tgz",
-      "integrity": "sha1-5pCLdtTIi+PbZChGu4tFXwv7HE4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/webextension-polyfill": {
-      "version": "0.8.2",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/webextension-polyfill/-/webextension-polyfill-0.8.2.tgz",
-      "integrity": "sha1-2Qk3HTMs4+GpRoRiTesKhpPu6QA=",
+      "version": "0.8.3",
       "dev": true,
       "license": "MIT"
     }
@@ -59,8 +49,6 @@
   "dependencies": {
     "@types/chrome": {
       "version": "0.0.174",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/chrome/-/chrome-0.0.174.tgz",
-      "integrity": "sha1-7hZ586T8V7ssO3aVeEWmivt9R4w=",
       "dev": true,
       "requires": {
         "@types/filesystem": "*",
@@ -69,8 +57,6 @@
     },
     "@types/filesystem": {
       "version": "0.0.32",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha1-MH33zAhKIpPDwaMRUbF4Bj4Kjt8=",
       "dev": true,
       "requires": {
         "@types/filewriter": "*"
@@ -78,20 +64,14 @@
     },
     "@types/filewriter": {
       "version": "0.0.29",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha1-pIeV7K35V/bA0Q4MNK+GwJj6W+4=",
       "dev": true
     },
     "@types/har-format": {
       "version": "1.2.8",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/har-format/-/har-format-1.2.8.tgz",
-      "integrity": "sha1-5pCLdtTIi+PbZChGu4tFXwv7HE4=",
       "dev": true
     },
     "@types/webextension-polyfill": {
-      "version": "0.8.2",
-      "resolved": "https://zoominfo.jfrog.io/artifactory/api/npm/virtual-npm/@types/webextension-polyfill/-/webextension-polyfill-0.8.2.tgz",
-      "integrity": "sha1-2Qk3HTMs4+GpRoRiTesKhpPu6QA=",
+      "version": "0.8.3",
       "dev": true
     }
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,5 +19,13 @@
     "scripts": [
       "scripts/bg.js"
     ]
+  },
+  "commands": {
+    "_cmd_openIn12ft": {
+      "suggested_key": {
+        "default": "Alt+Shift+P"
+      },
+      "description": "Open the page on 12ft.io"
+    }
   }
 }

--- a/src/scripts/bg.js
+++ b/src/scripts/bg.js
@@ -1,4 +1,22 @@
-chrome.browserAction.onClicked.addListener((tab) => {
-    const url = 'https://12ft.io/' +  tab.url;
+function onCommand(command) {
+    if (command === '_cmd_openIn12ft') {
+        // Browser Action popup pages aren't part of any tab, so tabs.getCurrent() won't work.
+        // We need to use browser.tabs.query instead.
+        browser.tabs.query({ currentWindow: true, active: true }, tabs => {
+            if (tabs && tabs[0].url.startsWith('http')) {
+                reopenIn12ft(tabs[0]);
+            }
+        });
+    }
+}
+
+function reopenIn12ft(tab) {
+    const url = `https://12ft.io/${tab.url}`;
     browser.tabs.update(tab.id, {url});
+}
+
+chrome.browserAction.onClicked.addListener((tab) => {
+    reopenIn12ft(tab);
 });
+
+browser.commands.onCommand.addListener(onCommand);


### PR DESCRIPTION
Adds a keyboard shortcut (Shift+Option+P by default) to open the page in
the current tab on 12ft.io.

The shortcut can be customised by the user in the browser settings. Happy to change the default to whatever you think is suitable.

Also removes the hard-coded URL for the private registry.

Resolves: #2 